### PR TITLE
backend fix, check for existing account number function

### DIFF
--- a/scripts/models/users.php
+++ b/scripts/models/users.php
@@ -204,13 +204,19 @@
         private function check_for_existing_acc_num($conn)
         {
             $this->sql = 'SELECT count(*) FROM '
-                            . $this::TABLE_NAME
-                            . ' WHERE '
-                            . $this::ACCOUNT_NUMBER . ' = ' . $this->account_number;
+                . $this::TABLE_NAME
+                . ' WHERE '
+                . $this::ACCOUNT_NUMBER . ' = ?';
 
-            $result = $conn->query($this->sql);
+            $stmt = $conn->prepare($this->sql);
+            $stmt->bind_param('s', $this->account_number);
+            $stmt->execute();
 
-            return $result;
+            $result = $stmt->get_result();
+            $row = $result->fetch_assoc();
+            $count = $row['count(*)'];
+
+            return $count > 0;
         }
     }
 ?>


### PR DESCRIPTION
## Fix for check_for_existing_acc_num function.
The problem seemed to be directly proving the account value. So we used query parameter instead to fix it

The error:

> Fatal error: Uncaught mysqli_sql_exception: Unknown column 'SAVE2205970178488438883400' in 'where clause' in E:\xampp\htdocs\Internet_Technologies_Project\scripts\models\users.php:211 Stack trace: #0 E:\xampp\htdocs\Internet_Technologies_Project\scripts\models\users.php(211): mysqli->query('SELECT count(*)...') #1 E:\xampp\htdocs\Internet_Technologies_Project\scripts\models\users.php(200): Users->check_for_existing_acc_num(Object(mysqli)) #2 E:\xampp\htdocs\Internet_Technologies_Project\scripts\models\users.php(90): Users->generate_account_number(Object(mysqli)) #3 E:\xampp\htdocs\Internet_Technologies_Project\scripts\handlers\user_handler.php(51): Users->register(Object(mysqli)) #4 E:\xampp\htdocs\Internet_Technologies_Project\scripts\handlers\user_handler.php(28): user_register_handle(Object(mysqli), Object(Users)) #5 {main} thrown in E:\xampp\htdocs\Internet_Technologies_Project\scripts\models\users.php on line 211

Please check it, if it works on your machine